### PR TITLE
Require composer/composer only in dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,9 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "composer-plugin-api": "^1.0 || ^2.0",
+        "composer-plugin-api": "^1.0 || ^2.0"
+    },
+    "require-dev": {
         "composer/composer": "^1.0 || ^2.0"
     },
     "extra": {


### PR DESCRIPTION
The package `composer/composer` is optional and useful in development due to IDE autocompletion, see  https://getcomposer.org/doc/articles/plugins.md#plugin-package.